### PR TITLE
Prototype pollution (Fixed)

### DIFF
--- a/src/objectDeepMerge.ts
+++ b/src/objectDeepMerge.ts
@@ -5,6 +5,9 @@ import { expectedObjType, ExpectedObjType, isCircularStructure } from './utils'
 function merge(target: any, ...rest: any[]) {
   rest.forEach(obj => {
     Object.entries(obj).forEach(([key, val]: [string, any]) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return target;
+      }
       const obj1 = target[key]
       if (expectedObjType(val) && expectedObjType(obj1)) {
         merge(obj1, val)


### PR DESCRIPTION
```@livelybone/copy``` is vulnerable to Prototype Pollution.
POC
```javascript
var copy = require("@livelybone/copy")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
copy.objectDeepMerge(obj, payload);
console.log("After : " + {}.polluted);
```
OUTPUT
```
Before : undefined
After : Yes! Its Polluted
```
With this fix this vulnerability can be avoided.